### PR TITLE
Namespacing keydown event to remove global effects

### DIFF
--- a/guiders-1.3.0.js
+++ b/guiders-1.3.0.js
@@ -168,7 +168,7 @@ var guiders = (function($) {
   };
 
   guiders._wireEscape = function (myGuider) {
-    $(document).keydown(function(event) {
+    $(document).bind("keydown.guiders", function(event) {
       if (event.keyCode == 27 || event.which == 27) {
         guiders.hideAll();
         if (myGuider.onClose) {
@@ -180,7 +180,7 @@ var guiders = (function($) {
   };
 
   guiders._unWireEscape = function (myGuider) {
-    $(document).unbind("keydown");
+    $(document).unbind("keydown.guiders");
   };
   
   guiders._attach = function(myGuider) {


### PR DESCRIPTION
Calling `$(document).unbind("keydown");` without using a namespace or passing in the original handler function unbinds all keydown event listeners attached to the document, not just ones attached by Guiders. This does not play friendly with other code that is attaching to this same event.